### PR TITLE
Remove custom icon filename for Grafana Alloy

### DIFF
--- a/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
@@ -16,7 +16,6 @@ Input:
     description: Grafana Alloy agent for collecting metrics and logs. Config files should be added to /Library/GrafanaAlloy/config.d.
     developer: Grafana
     display_name: Grafana Alloy
-    icon_name: GrafanaAlloy
     name: '%NAME%'
     supported_architectures:
     - '%SUPPORTED_ARCH%'


### PR DESCRIPTION
This change allows administrators to provide an icon at `icons/grafana_alloy.png` which will be used by Munki for Grafana Alloy. Admins can provide a custom `icon_name` in their override if they choose, but aren't forced to inherit it from this parent.