### PR TITLE
Fleet management

### DIFF
--- a/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
@@ -6,9 +6,8 @@ Input:
   NAME: grafana_alloy
   MUNKI_REPO_SUBDIR: apps
   ALLOY_CONFIG: |
-    logging {
-      level  = "info"
-      format = "logfmt"
+    local.file "local_context" {
+      filename = "/Library/GrafanaAlloy/local_context.json"
     }
   GCLOUD_RW_API_KEY: ''
   ARCH: arm64
@@ -19,7 +18,7 @@ Input:
     - testing
     - stable
     category: Engineering
-    description: Grafana Alloy agent for collecting metrics and logs. Config files should be added to /Library/GrafanaAlloy/config.d.
+    description: Grafana Alloy agent for collecting metrics and logs. Configure using Grafana Cloud Fleet Management.
     developer: Grafana
     display_name: Grafana Alloy
     name: '%NAME%'

--- a/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
@@ -21,6 +21,7 @@ Input:
     description: Grafana Alloy agent for collecting metrics and logs. Configure using Grafana Cloud Fleet Management.
     developer: Grafana
     display_name: Grafana Alloy
+    minimum_os_version: 10.13
     name: '%NAME%'
     supported_architectures:
     - '%SUPPORTED_ARCH%'

--- a/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.munki.recipe.yaml
@@ -5,6 +5,12 @@ ParentRecipe: com.llamafilm.pkg.grafana_alloy
 Input:
   NAME: grafana_alloy
   MUNKI_REPO_SUBDIR: apps
+  ALLOY_CONFIG: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+  GCLOUD_RW_API_KEY: ''
   ARCH: arm64
   SUPPORTED_ARCH: arm64
   pkginfo:

--- a/GrafanaAlloy/grafana_alloy.pkg.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.pkg.recipe.yaml
@@ -1,5 +1,6 @@
 Description: |
   Packages Grafana Alloy with a LaunchDaemon and a minimal config file.
+  Override the ALLOY_CONFIG file contents and GCLOUD_RW_API_KEY for Fleet Management.
 Identifier: com.llamafilm.pkg.grafana_alloy
 MinimumVersion: 2.3.0
 ParentRecipe: com.llamafilm.download.grafana_alloy
@@ -7,6 +8,12 @@ ParentRecipe: com.llamafilm.download.grafana_alloy
 Input:
   ARCH: arm64
   NAME: grafana_alloy
+  ALLOY_CONFIG: |
+    logging {
+      level  = "info"
+      format = "logfmt"
+    }
+  GCLOUD_RW_API_KEY: ''
 Process:
 - Processor: PkgRootCreator
   Arguments:
@@ -38,11 +45,7 @@ Process:
 - Processor: FileCreator
   Arguments:
     file_path: '%pkgroot%/root/Library/GrafanaAlloy/config.alloy'
-    file_content: |
-      logging {
-        level  = "debug"
-        format = "logfmt"
-      }
+    file_content: '%ALLOY_CONFIG%'
     file_mode: '0644'
 
 - Processor: FileCreator
@@ -74,6 +77,11 @@ Process:
               <string>--storage.path</string>
               <string>/Library/GrafanaAlloy/data</string>
           </array>
+          <key>EnvironmentVariables</key>
+          <dict>
+              <key>GCLOUD_RW_API_KEY</key>
+              <string>%GCLOUD_RW_API_KEY%</string>
+          </dict>
       </dict>
       </plist>
     file_mode: '0644'

--- a/GrafanaAlloy/grafana_alloy.pkg.recipe.yaml
+++ b/GrafanaAlloy/grafana_alloy.pkg.recipe.yaml
@@ -1,5 +1,6 @@
 Description: |
   Packages Grafana Alloy with a LaunchDaemon and a minimal config file.
+  Also writes the Mac serial to a JSON file that can be used in the Alloy config.
   Override the ALLOY_CONFIG file contents and GCLOUD_RW_API_KEY for Fleet Management.
 Identifier: com.llamafilm.pkg.grafana_alloy
 MinimumVersion: 2.3.0
@@ -9,9 +10,8 @@ Input:
   ARCH: arm64
   NAME: grafana_alloy
   ALLOY_CONFIG: |
-    logging {
-      level  = "info"
-      format = "logfmt"
+    local.file "local_context" {
+      filename = "/Library/GrafanaAlloy/local_context.json"
     }
   GCLOUD_RW_API_KEY: ''
 Process:
@@ -39,6 +39,9 @@ Process:
     file_path: '%pkgroot%/scripts/postinstall'
     file_content: |
       #!/bin/sh
+      # Write the Mac serial to JSON file for optional use as a label or attribute
+      SERIAL=$(ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformSerialNumber | cut -d '"' -f4)
+      echo "{\"serial\": \"$SERIAL\"}" > /Library/GrafanaAlloy/local_context.json
       /bin/launchctl load /Library/LaunchDaemons/com.grafana.alloy.plist 2>/dev/null
     file_mode: '0755'
 


### PR DESCRIPTION
Update Grafana Alloy recipe for use with Grafana Cloud Fleet Management.

The installer writes the Mac serial number to a JSON file where it can be read by Alloy. API token is passed to Alloy as an environment variable in the LaunchDaemon. Users are expected to override the full config file contents and API key with variables.

Also update minimum MacOS version to 10.13.

Example override for ALLOY_CONFIG:
```yaml
    local.file "local_context" {
      filename = "/Library/GrafanaAlloy/local_context.json"
    }
    remotecfg {
      url = "https://fleet-management-prod-008.grafana.net"
      basic_auth {
        username = "11111111"
        password = sys.env("GCLOUD_RW_API_KEY")
      }
      id             = constants.hostname
      attributes     = {
        "serial" = json_decode(local.file.local_context.content).serial,
      }
      poll_frequency = "5m"
    }
```